### PR TITLE
Remove unused `use` statement

### DIFF
--- a/CartPositionTrait.php
+++ b/CartPositionTrait.php
@@ -3,7 +3,6 @@
 namespace yz\shoppingcart;
 
 use yii\base\Component;
-use yii\base\Object;
 
 /**
  * Trait CartPositionTrait


### PR DESCRIPTION
This commit fixes PHP 7.2 compatibility

@omnilight Could you issue a release, please?